### PR TITLE
Refactor and Rebrand Client Package to `httpkit` with Enhanced Proxy and FlowID Support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -52,21 +52,21 @@ import (
 	"io"
 	"log"
 
+	"github.com/Mathious6/httpkit"
 	http "github.com/bogdanfinn/fhttp"
-	tls_client "github.com/bogdanfinn/tls-client"
-	"github.com/bogdanfinn/tls-client/profiles"
+	"github.com/Mathious6/httpkit/profiles"
 )
 
 func main() {
-    jar := tls_client.NewCookieJar()
-	options := []tls_client.HttpClientOption{
-		tls_client.WithTimeoutSeconds(30),
-		tls_client.WithClientProfile(profiles.Chrome_120),
-		tls_client.WithNotFollowRedirects(),
-		tls_client.WithCookieJar(jar), // create cookieJar instance and pass it as argument
+    jar := httpkit.NewCookieJar()
+	options := []httpkit.HttpClientOption{
+		httpkit.WithTimeoutSeconds(30),
+		httpkit.WithClientProfile(profiles.Chrome_120),
+		httpkit.WithNotFollowRedirects(),
+		httpkit.WithCookieJar(jar), // create cookieJar instance and pass it as argument
 	}
 
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
+	client, err := httpkit.NewHttpClient(httpkit.NewNoopLogger(), options...)
 	if err != nil {
 		log.Println(err)
 		return
@@ -122,4 +122,3 @@ No Support in DMs!
 ### Appreciate my work?
 
 [!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/CaptainBarnius)
-

--- a/client.go
+++ b/client.go
@@ -10,11 +10,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Mathious6/httpkit/bandwidth"
 	"github.com/Mathious6/httpkit/profiles"
 	"github.com/Mathious6/platekit"
 	http "github.com/bogdanfinn/fhttp"
 	"github.com/bogdanfinn/fhttp/httputil"
-	"github.com/bogdanfinn/tls-client/bandwidth"
 	"golang.org/x/net/proxy"
 )
 

--- a/client.go
+++ b/client.go
@@ -10,11 +10,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Mathious6/platekit"
 	http "github.com/bogdanfinn/fhttp"
 	"github.com/bogdanfinn/fhttp/httputil"
 	"github.com/bogdanfinn/tls-client/bandwidth"
 	"github.com/bogdanfinn/tls-client/profiles"
-	"github.com/google/uuid"
 	"golang.org/x/net/proxy"
 )
 
@@ -106,9 +106,8 @@ func NewHttpClient(logger Logger, options ...HttpClientOption) (HttpClient, erro
 		logger = NewDebugLogger(logger)
 	}
 
-	// TODO: implement hashkit to generate flowId
 	if config.flowId == "" {
-		config.flowId = uuid.NewString()
+		config.flowId = platekit.Generate()
 	}
 
 	return &httpClient{

--- a/client.go
+++ b/client.go
@@ -1,4 +1,4 @@
-package tls_client
+package httpkit
 
 import (
 	"bytes"
@@ -10,11 +10,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Mathious6/httpkit/profiles"
 	"github.com/Mathious6/platekit"
 	http "github.com/bogdanfinn/fhttp"
 	"github.com/bogdanfinn/fhttp/httputil"
 	"github.com/bogdanfinn/tls-client/bandwidth"
-	"github.com/bogdanfinn/tls-client/profiles"
 	"golang.org/x/net/proxy"
 )
 

--- a/client_options.go
+++ b/client_options.go
@@ -53,6 +53,7 @@ type httpClientConfig struct {
 	dialer             net.Dialer
 	proxyDialerFactory ProxyDialerFactory
 
+	flowId                      string
 	proxyUrl                    string
 	serverNameOverwrite         string
 	clientProfile               profiles.ClientProfile
@@ -70,6 +71,13 @@ type httpClientConfig struct {
 	disableIPV4 bool
 
 	enabledBandwidthTracker bool
+}
+
+// WithFlowId configures a HTTP client to use the specified flow id.
+func WithFlowId(flowId string) HttpClientOption {
+	return func(config *httpClientConfig) {
+		config.flowId = flowId
+	}
 }
 
 // WithProxyUrl configures a HTTP client to use the specified proxy URL.

--- a/client_options.go
+++ b/client_options.go
@@ -119,6 +119,15 @@ func WithTimeoutMilliseconds(timeout int) HttpClientOption {
 	}
 }
 
+// WithTimeoutSeconds configures an HTTP client to use the specified request timeout.
+//
+// timeout is the request timeout in seconds.
+func WithTimeoutSeconds(timeout int) HttpClientOption {
+	return func(config *httpClientConfig) {
+		config.timeout = time.Second * time.Duration(timeout)
+	}
+}
+
 // WithDialer configures an HTTP client to use the specified dialer. This allows the use of a custom DNS resolver
 func WithDialer(dialer net.Dialer) HttpClientOption {
 	return func(config *httpClientConfig) {
@@ -130,25 +139,6 @@ func WithDialer(dialer net.Dialer) HttpClientOption {
 func WithProxyDialerFactory(proxyDialerFactory ProxyDialerFactory) HttpClientOption {
 	return func(config *httpClientConfig) {
 		config.proxyDialerFactory = proxyDialerFactory
-	}
-}
-
-// WithTimeoutSeconds configures an HTTP client to use the specified request timeout.
-//
-// timeout is the request timeout in seconds.
-func WithTimeoutSeconds(timeout int) HttpClientOption {
-	return func(config *httpClientConfig) {
-		config.timeout = time.Second * time.Duration(timeout)
-	}
-}
-
-// WithTimeout configures an HTTP client to use the specified request timeout.
-//
-// timeout is the request timeout in seconds.
-// Deprecated: use either WithTimeoutSeconds or WithTimeoutMilliseconds
-func WithTimeout(timeout int) HttpClientOption {
-	return func(config *httpClientConfig) {
-		config.timeout = time.Second * time.Duration(timeout)
 	}
 }
 

--- a/client_options.go
+++ b/client_options.go
@@ -1,4 +1,4 @@
-package tls_client
+package httpkit
 
 import (
 	"crypto/x509"
@@ -7,8 +7,8 @@ import (
 	"net"
 	"time"
 
+	"github.com/Mathious6/httpkit/profiles"
 	http "github.com/bogdanfinn/fhttp"
-	"github.com/bogdanfinn/tls-client/profiles"
 	"golang.org/x/net/proxy"
 )
 

--- a/connect.go
+++ b/connect.go
@@ -1,4 +1,4 @@
-package tls_client
+package httpkit
 
 import (
 	"bufio"

--- a/example/main.go
+++ b/example/main.go
@@ -11,11 +11,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/bogdanfinn/tls-client/profiles"
+	"github.com/Mathious6/httpkit/profiles"
 
+	"github.com/Mathious6/httpkit"
 	http "github.com/bogdanfinn/fhttp"
 	"github.com/bogdanfinn/fhttp/http2"
-	tls_client "github.com/bogdanfinn/tls-client"
 	tls "github.com/bogdanfinn/utls"
 )
 
@@ -151,7 +151,7 @@ type TlsApiResponse struct {
 }
 
 func sslPinning() {
-	jar := tls_client.NewCookieJar()
+	jar := httpkit.NewCookieJar()
 
 	//	I generated the pins by running the following command:
 	//	➜ hpkp-pins -server=bstn.com:443
@@ -164,16 +164,16 @@ func sslPinning() {
 		},
 	}
 
-	options := []tls_client.HttpClientOption{
-		tls_client.WithTimeoutSeconds(60),
-		tls_client.WithClientProfile(profiles.Chrome_107),
-		tls_client.WithRandomTLSExtensionOrder(),
-		tls_client.WithCookieJar(jar),
-		tls_client.WithCertificatePinning(pins, tls_client.DefaultBadPinHandler),
-		tls_client.WithCharlesProxy("127.0.0.1", "8888"),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithTimeoutSeconds(60),
+		httpkit.WithClientProfile(profiles.Chrome_107),
+		httpkit.WithRandomTLSExtensionOrder(),
+		httpkit.WithCookieJar(jar),
+		httpkit.WithCertificatePinning(pins, httpkit.DefaultBadPinHandler),
+		httpkit.WithCharlesProxy("127.0.0.1", "8888"),
 	}
 
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
+	client, err := httpkit.NewHttpClient(httpkit.NewNoopLogger(), options...)
 	if err != nil {
 		log.Println(err)
 		return
@@ -224,19 +224,19 @@ func sslPinning() {
 }
 
 func requestToppsAsChrome107Client() {
-	jar := tls_client.NewCookieJar()
+	jar := httpkit.NewCookieJar()
 
-	options := []tls_client.HttpClientOption{
-		tls_client.WithTimeoutSeconds(30),
-		tls_client.WithClientProfile(profiles.Chrome_107),
-		tls_client.WithDebug(),
-		// tls_client.WithProxyUrl("http://user:pass@host:port"),
-		// tls_client.WithNotFollowRedirects(),
-		// tls_client.WithInsecureSkipVerify(),
-		tls_client.WithCookieJar(jar), // create cookieJar instance and pass it as argument
+	options := []httpkit.HttpClientOption{
+		httpkit.WithTimeoutSeconds(30),
+		httpkit.WithClientProfile(profiles.Chrome_107),
+		httpkit.WithDebug(),
+		// httpkit.WithProxyUrl("http://user:pass@host:port"),
+		// httpkit.WithNotFollowRedirects(),
+		// httpkit.WithInsecureSkipVerify(),
+		httpkit.WithCookieJar(jar), // create cookieJar instance and pass it as argument
 	}
 
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
+	client, err := httpkit.NewHttpClient(httpkit.NewNoopLogger(), options...)
 	if err != nil {
 		log.Println(err)
 		return
@@ -302,12 +302,12 @@ func requestToppsAsChrome107Client() {
 }
 
 func postAsTlsClient() {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithTimeoutSeconds(30),
-		tls_client.WithClientProfile(profiles.Chrome_107),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithTimeoutSeconds(30),
+		httpkit.WithClientProfile(profiles.Chrome_107),
 	}
 
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
+	client, err := httpkit.NewHttpClient(httpkit.NewNoopLogger(), options...)
 	if err != nil {
 		log.Println(err)
 		return
@@ -350,13 +350,13 @@ func postAsTlsClient() {
 }
 
 func requestWithFollowRedirectSwitch() {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithTimeoutSeconds(30),
-		tls_client.WithClientProfile(profiles.Chrome_107),
-		tls_client.WithNotFollowRedirects(),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithTimeoutSeconds(30),
+		httpkit.WithClientProfile(profiles.Chrome_107),
+		httpkit.WithNotFollowRedirects(),
 	}
 
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
+	client, err := httpkit.NewHttpClient(httpkit.NewNoopLogger(), options...)
 	if err != nil {
 		log.Println(err)
 		return
@@ -426,13 +426,13 @@ func requestWithFollowRedirectSwitch() {
 }
 
 func downloadImageWithTlsClient() {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithTimeoutSeconds(30),
-		tls_client.WithClientProfile(profiles.Chrome_107),
-		tls_client.WithNotFollowRedirects(),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithTimeoutSeconds(30),
+		httpkit.WithClientProfile(profiles.Chrome_107),
+		httpkit.WithNotFollowRedirects(),
 	}
 
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
+	client, err := httpkit.NewHttpClient(httpkit.NewNoopLogger(), options...)
 	if err != nil {
 		log.Println(err)
 		return
@@ -483,13 +483,13 @@ func downloadImageWithTlsClient() {
 }
 
 func rotateProxiesOnClient() {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithTimeoutSeconds(30),
-		tls_client.WithClientProfile(profiles.Chrome_107),
-		tls_client.WithProxyUrl("http://user:pass@host:port"), // you can also use socks5://user:pass@host:port or socks5h://user:pass@host:port
+	options := []httpkit.HttpClientOption{
+		httpkit.WithTimeoutSeconds(30),
+		httpkit.WithClientProfile(profiles.Chrome_107),
+		httpkit.WithProxyUrl("http://user:pass@host:port"), // you can also use socks5://user:pass@host:port or socks5h://user:pass@host:port
 	}
 
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
+	client, err := httpkit.NewHttpClient(httpkit.NewNoopLogger(), options...)
 	if err != nil {
 		log.Println(err)
 		return
@@ -693,12 +693,12 @@ func requestWithCustomClient() {
 		SpecFactory: specFactory,
 	}, settings, settingsOrder, pseudoHeaderOrder, connectionFlow, nil, nil)
 
-	options := []tls_client.HttpClientOption{
-		tls_client.WithTimeoutSeconds(60),
-		tls_client.WithClientProfile(customClientProfile), // use custom profile here
+	options := []httpkit.HttpClientOption{
+		httpkit.WithTimeoutSeconds(60),
+		httpkit.WithClientProfile(customClientProfile), // use custom profile here
 	}
 
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
+	client, err := httpkit.NewHttpClient(httpkit.NewNoopLogger(), options...)
 	if err != nil {
 		log.Println(err)
 		return
@@ -794,7 +794,7 @@ func requestWithJa3CustomClientWithTwoGreaseExtensions() {
 	keyShareCurves := []string{"GREASE", "X25519Kyber768", "X25519"}
 	supportedProtocolsALPN := []string{"h2", "http/1.1"}
 	supportedProtocolsALPS := []string{"h2"}
-	echCandidateCipherSuites := []tls_client.CandidateCipherSuites{
+	echCandidateCipherSuites := []httpkit.CandidateCipherSuites{
 		{
 			KdfId:  "HKDF_SHA256",
 			AeadId: "AEAD_AES_128_GCM",
@@ -807,7 +807,7 @@ func requestWithJa3CustomClientWithTwoGreaseExtensions() {
 	candidatePayloads := []uint16{128, 160, 192, 224}
 	certCompressionAlgos := []string{"brotli"}
 
-	specFactory, err := tls_client.GetSpecFactoryFromJa3String(ja3String, supportedSignatureAlgorithms, supportedDelegatedCredentialsAlgorithms, supportedVersions, keyShareCurves, supportedProtocolsALPN, supportedProtocolsALPS, echCandidateCipherSuites, candidatePayloads, certCompressionAlgos, 0)
+	specFactory, err := httpkit.GetSpecFactoryFromJa3String(ja3String, supportedSignatureAlgorithms, supportedDelegatedCredentialsAlgorithms, supportedVersions, keyShareCurves, supportedProtocolsALPN, supportedProtocolsALPS, echCandidateCipherSuites, candidatePayloads, certCompressionAlgos, 0)
 
 	customClientProfile := profiles.NewClientProfile(tls.ClientHelloID{
 		Client:      "MyCustomProfile",
@@ -816,12 +816,12 @@ func requestWithJa3CustomClientWithTwoGreaseExtensions() {
 		SpecFactory: specFactory,
 	}, settings, settingsOrder, pseudoHeaderOrder, connectionFlow, nil, nil)
 
-	options := []tls_client.HttpClientOption{
-		tls_client.WithTimeoutSeconds(60),
-		tls_client.WithClientProfile(customClientProfile), // use custom profile here
+	options := []httpkit.HttpClientOption{
+		httpkit.WithTimeoutSeconds(60),
+		httpkit.WithClientProfile(customClientProfile), // use custom profile here
 	}
 
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
+	client, err := httpkit.NewHttpClient(httpkit.NewNoopLogger(), options...)
 	if err != nil {
 		log.Println(err)
 		return
@@ -959,12 +959,12 @@ func testPskExtension() {
 		SpecFactory: specFactory,
 	}, settings, settingsOrder, pseudoHeaderOrder, connectionFlow, nil, nil)
 
-	options := []tls_client.HttpClientOption{
-		tls_client.WithTimeoutSeconds(60),
-		tls_client.WithClientProfile(customClientProfile),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithTimeoutSeconds(60),
+		httpkit.WithClientProfile(customClientProfile),
 	}
 
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
+	client, err := httpkit.NewHttpClient(httpkit.NewNoopLogger(), options...)
 	if err != nil {
 		log.Println(err)
 		return
@@ -1055,12 +1055,12 @@ func testPskExtension() {
 }
 
 func testALPSExtension() {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithTimeoutSeconds(60),
-		tls_client.WithClientProfile(profiles.Chrome_133),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithTimeoutSeconds(60),
+		httpkit.WithClientProfile(profiles.Chrome_133),
 	}
 
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
+	client, err := httpkit.NewHttpClient(httpkit.NewNoopLogger(), options...)
 	if err != nil {
 		log.Println(err)
 		return

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/bogdanfinn/tls-client
 
-go 1.24.1
+go 1.24.3
 
 require (
 	github.com/Dharmey747/quic-go-utls v1.0.3-utls
+	github.com/Mathious6/platekit v1.0.0
 	github.com/bogdanfinn/fhttp v0.6.0
 	github.com/bogdanfinn/utls v1.7.3-barnius
-	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tam7t/hpkp v0.0.0-20160821193359-2b70b4024ed5
 	golang.org/x/net v0.38.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bogdanfinn/tls-client
+module github.com/Mathious6/httpkit
 
 go 1.24.3
 
@@ -6,6 +6,7 @@ require (
 	github.com/Dharmey747/quic-go-utls v1.0.3-utls
 	github.com/Mathious6/platekit v1.0.0
 	github.com/bogdanfinn/fhttp v0.6.0
+	github.com/bogdanfinn/tls-client v1.11.0
 	github.com/bogdanfinn/utls v1.7.3-barnius
 	github.com/stretchr/testify v1.9.0
 	github.com/tam7t/hpkp v0.0.0-20160821193359-2b70b4024ed5

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/cloudflare/circl v1.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Dharmey747/quic-go-utls v1.0.3-utls
 	github.com/bogdanfinn/fhttp v0.6.0
 	github.com/bogdanfinn/utls v1.7.3-barnius
+	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tam7t/hpkp v0.0.0-20160821193359-2b70b4024ed5
 	golang.org/x/net v0.38.0
@@ -15,7 +16,6 @@ require (
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/cloudflare/circl v1.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Dharmey747/quic-go-utls v1.0.3-utls
 	github.com/Mathious6/platekit v1.0.0
 	github.com/bogdanfinn/fhttp v0.6.0
-	github.com/bogdanfinn/tls-client v1.11.0
 	github.com/bogdanfinn/utls v1.7.3-barnius
 	github.com/stretchr/testify v1.9.0
 	github.com/tam7t/hpkp v0.0.0-20160821193359-2b70b4024ed5
@@ -29,7 +28,3 @@ require (
 	golang.org/x/tools v0.22.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// replace github.com/bogdanfinn/utls => ../utls
-
-// replace github.com/bogdanfinn/fhttp => ../fhttp

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7X
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
 github.com/bogdanfinn/fhttp v0.6.0 h1:24JoDnE43tq3RdK99K1M5mxa2JyntKr6WcDsy1KdA0o=
 github.com/bogdanfinn/fhttp v0.6.0/go.mod h1:ZR1hRfxsOd/j/C8RnwyNXA90DxkrHB3Y1nuCD1YlbdI=
-github.com/bogdanfinn/tls-client v1.11.0 h1:JCSSf2CSEHPB6Rk8amTeaW84iXdapDbjVl6O4/s1sn8=
-github.com/bogdanfinn/tls-client v1.11.0/go.mod h1:3GkHek7BLiVBWnBCvSjiTl5mzgdVuUnjac6oIY4scXI=
 github.com/bogdanfinn/utls v1.7.3-barnius h1:2p9riIoGHI85eVDebhHm58qLokyJ8bFEn26wg24S1uU=
 github.com/bogdanfinn/utls v1.7.3-barnius/go.mod h1:SUn0CoHGVp/akGNuaqh99yvovu64PCP2LbWd3Z/Laic=
 github.com/cloudflare/circl v1.5.0 h1:hxIWksrX6XN5a1L2TI/h53AGPhNHoUBo+TD1ms9+pys=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7X
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
 github.com/bogdanfinn/fhttp v0.6.0 h1:24JoDnE43tq3RdK99K1M5mxa2JyntKr6WcDsy1KdA0o=
 github.com/bogdanfinn/fhttp v0.6.0/go.mod h1:ZR1hRfxsOd/j/C8RnwyNXA90DxkrHB3Y1nuCD1YlbdI=
+github.com/bogdanfinn/tls-client v1.11.0 h1:JCSSf2CSEHPB6Rk8amTeaW84iXdapDbjVl6O4/s1sn8=
+github.com/bogdanfinn/tls-client v1.11.0/go.mod h1:3GkHek7BLiVBWnBCvSjiTl5mzgdVuUnjac6oIY4scXI=
 github.com/bogdanfinn/utls v1.7.3-barnius h1:2p9riIoGHI85eVDebhHm58qLokyJ8bFEn26wg24S1uU=
 github.com/bogdanfinn/utls v1.7.3-barnius/go.mod h1:SUn0CoHGVp/akGNuaqh99yvovu64PCP2LbWd3Z/Laic=
 github.com/cloudflare/circl v1.5.0 h1:hxIWksrX6XN5a1L2TI/h53AGPhNHoUBo+TD1ms9+pys=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Dharmey747/quic-go-utls v1.0.3-utls h1:wqvk69LgFwT6AtTW14ASpRIJkvCaH21dX/U5ov5STr0=
 github.com/Dharmey747/quic-go-utls v1.0.3-utls/go.mod h1:lgQoyZzST8vJJQ84eF9Xi2xJJnujoiNk0FGFEyQonG8=
+github.com/Mathious6/platekit v1.0.0 h1:XoS0C1KiMKZem8mvD2VE1fvwS/1DT9Vc9u/dVdV69zY=
+github.com/Mathious6/platekit v1.0.0/go.mod h1:bMXoVaS2ziTocqDm4rzMFuC8eiUFYpUIa+hXHymt8i8=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
 github.com/bogdanfinn/fhttp v0.6.0 h1:24JoDnE43tq3RdK99K1M5mxa2JyntKr6WcDsy1KdA0o=
@@ -10,8 +12,6 @@ github.com/cloudflare/circl v1.5.0 h1:hxIWksrX6XN5a1L2TI/h53AGPhNHoUBo+TD1ms9+py
 github.com/cloudflare/circl v1.5.0/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/cloudflare/circl v1.5.0 h1:hxIWksrX6XN5a1L2TI/h53AGPhNHoUBo+TD1ms9+py
 github.com/cloudflare/circl v1.5.0/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/ja3.go
+++ b/ja3.go
@@ -1,4 +1,4 @@
-package tls_client
+package httpkit
 
 import (
 	"crypto/sha256"

--- a/jar.go
+++ b/jar.go
@@ -1,4 +1,4 @@
-package tls_client
+package httpkit
 
 import (
 	"fmt"

--- a/jar_test.go
+++ b/jar_test.go
@@ -1,4 +1,4 @@
-package tls_client
+package httpkit
 
 import (
 	"net/url"

--- a/logger.go
+++ b/logger.go
@@ -1,4 +1,4 @@
-package tls_client
+package httpkit
 
 import "fmt"
 

--- a/mapper.go
+++ b/mapper.go
@@ -1,4 +1,4 @@
-package tls_client
+package httpkit
 
 import (
 	"github.com/bogdanfinn/fhttp/http2"

--- a/pinner.go
+++ b/pinner.go
@@ -1,4 +1,4 @@
-package tls_client
+package httpkit
 
 import (
 	"errors"

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	"github.com/Dharmey747/quic-go-utls/http3"
+	"github.com/Mathious6/httpkit/bandwidth"
 	"github.com/Mathious6/httpkit/profiles"
 	http "github.com/bogdanfinn/fhttp"
 	"github.com/bogdanfinn/fhttp/http2"
-	"github.com/bogdanfinn/tls-client/bandwidth"
 	tls "github.com/bogdanfinn/utls"
 	"golang.org/x/net/proxy"
 )

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -1,4 +1,4 @@
-package tls_client
+package httpkit
 
 import (
 	"context"
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	"github.com/Dharmey747/quic-go-utls/http3"
+	"github.com/Mathious6/httpkit/profiles"
 	http "github.com/bogdanfinn/fhttp"
 	"github.com/bogdanfinn/fhttp/http2"
 	"github.com/bogdanfinn/tls-client/bandwidth"
-	"github.com/bogdanfinn/tls-client/profiles"
 	tls "github.com/bogdanfinn/utls"
 	"golang.org/x/net/proxy"
 )

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -6,10 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bogdanfinn/tls-client/profiles"
-
+	"github.com/Mathious6/httpkit"
+	"github.com/Mathious6/httpkit/profiles"
 	http "github.com/bogdanfinn/fhttp"
-	tls_client "github.com/bogdanfinn/tls-client"
 	tls "github.com/bogdanfinn/utls"
 )
 
@@ -135,12 +134,12 @@ var defaultOkHttp4Header = http.Header{
 }
 
 func chrome116WithPsk(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_116_PSK),
-		tls_client.WithTimeoutSeconds(120),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_116_PSK),
+		httpkit.WithTimeoutSeconds(120),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,11 +174,11 @@ func chrome116WithPsk(t *testing.T) {
 }
 
 func chrome112(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_112),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_112),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,11 +199,11 @@ func chrome112(t *testing.T) {
 }
 
 func chrome111(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_111),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_111),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,11 +224,11 @@ func chrome111(t *testing.T) {
 }
 
 func chrome110(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_110),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_110),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,11 +249,11 @@ func chrome110(t *testing.T) {
 }
 
 func chrome109(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_109),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_109),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,11 +274,11 @@ func chrome109(t *testing.T) {
 }
 
 func chrome108(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_108),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_108),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -300,11 +299,11 @@ func chrome108(t *testing.T) {
 }
 
 func chrome107(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_107),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_107),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -325,11 +324,11 @@ func chrome107(t *testing.T) {
 }
 
 func chrome105(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_105),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_105),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -350,11 +349,11 @@ func chrome105(t *testing.T) {
 }
 
 func chrome104(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_104),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_104),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -375,11 +374,11 @@ func chrome104(t *testing.T) {
 }
 
 func chrome103(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_103),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_103),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,11 +399,11 @@ func chrome103(t *testing.T) {
 }
 
 func safari_16_0(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Safari_16_0),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Safari_16_0),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -425,11 +424,11 @@ func safari_16_0(t *testing.T) {
 }
 
 func safari_iOS_16_0(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Safari_IOS_16_0),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Safari_IOS_16_0),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -450,11 +449,11 @@ func safari_iOS_16_0(t *testing.T) {
 }
 
 func safari_iOS_18_0(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Safari_IOS_18_0),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Safari_IOS_18_0),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -475,11 +474,11 @@ func safari_iOS_18_0(t *testing.T) {
 }
 
 func firefox_105(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Firefox_105),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Firefox_105),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -500,11 +499,11 @@ func firefox_105(t *testing.T) {
 }
 
 func firefox_106(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Firefox_106),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Firefox_106),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -525,11 +524,11 @@ func firefox_106(t *testing.T) {
 }
 
 func firefox_108(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Firefox_108),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Firefox_108),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -550,11 +549,11 @@ func firefox_108(t *testing.T) {
 }
 
 func chrome_124(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_124),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_124),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -575,11 +574,11 @@ func chrome_124(t *testing.T) {
 }
 
 func chrome_133(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_133),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_133),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -600,11 +599,11 @@ func chrome_133(t *testing.T) {
 }
 
 func chrome_131(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_131),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_131),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -625,11 +624,11 @@ func chrome_131(t *testing.T) {
 }
 
 func chrome_120(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_120),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_120),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -650,11 +649,11 @@ func chrome_120(t *testing.T) {
 }
 
 func chrome_117(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_117),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_117),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -675,11 +674,11 @@ func chrome_117(t *testing.T) {
 }
 
 func firefox_117(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Firefox_117),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Firefox_117),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -700,11 +699,11 @@ func firefox_117(t *testing.T) {
 }
 
 func firefox_110(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Firefox_110),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Firefox_110),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -725,11 +724,11 @@ func firefox_110(t *testing.T) {
 }
 
 func firefox_132(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Firefox_132),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Firefox_132),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -750,11 +749,11 @@ func firefox_132(t *testing.T) {
 }
 
 func opera_91(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Opera_91),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Opera_91),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -775,11 +774,11 @@ func opera_91(t *testing.T) {
 }
 
 func safariIos17(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Safari_IOS_17_0),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Safari_IOS_17_0),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -835,11 +834,11 @@ func compareResponse(t *testing.T, clientName string, expectedValues map[string]
 }
 
 func okhttp4Android13(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Okhttp4Android13),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Okhttp4Android13),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -860,11 +859,11 @@ func okhttp4Android13(t *testing.T) {
 }
 
 func okhttp4Android12(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Okhttp4Android12),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Okhttp4Android12),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -885,11 +884,11 @@ func okhttp4Android12(t *testing.T) {
 }
 
 func okhttp4Android11(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Okhttp4Android11),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Okhttp4Android11),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -910,11 +909,11 @@ func okhttp4Android11(t *testing.T) {
 }
 
 func okhttp4Android10(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Okhttp4Android10),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Okhttp4Android10),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -935,11 +934,11 @@ func okhttp4Android10(t *testing.T) {
 }
 
 func okhttp4Android9(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Okhttp4Android9),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Okhttp4Android9),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -960,11 +959,11 @@ func okhttp4Android9(t *testing.T) {
 }
 
 func okhttp4Android8(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Okhttp4Android8),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Okhttp4Android8),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -985,11 +984,11 @@ func okhttp4Android8(t *testing.T) {
 }
 
 func okhttp4Android7(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Okhttp4Android7),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Okhttp4Android7),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/client_test_utils.go
+++ b/tests/client_test_utils.go
@@ -1,7 +1,7 @@
 package tests
 
 import (
-	"github.com/bogdanfinn/tls-client/profiles"
+	"github.com/Mathious6/httpkit/profiles"
 	tls "github.com/bogdanfinn/utls"
 )
 

--- a/tests/firefox_unsupported_group_test.go
+++ b/tests/firefox_unsupported_group_test.go
@@ -4,18 +4,18 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Mathious6/httpkit"
+	"github.com/Mathious6/httpkit/profiles"
 	http "github.com/bogdanfinn/fhttp"
-	tls_client "github.com/bogdanfinn/tls-client"
-	"github.com/bogdanfinn/tls-client/profiles"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWeb(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Firefox_110),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Firefox_110),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/header_order_test.go
+++ b/tests/header_order_test.go
@@ -5,19 +5,18 @@ import (
 	"io"
 	"testing"
 
-	"github.com/bogdanfinn/tls-client/profiles"
-
+	"github.com/Mathious6/httpkit"
+	"github.com/Mathious6/httpkit/profiles"
 	http "github.com/bogdanfinn/fhttp"
-	tls_client "github.com/bogdanfinn/tls-client"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_HeaderOrder(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_105),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_105),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,12 +99,12 @@ func TestClient_HeaderOrder(t *testing.T) {
 }
 
 func TestClient_HeaderOrderHttp1(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_105),
-		tls_client.WithForceHttp1(),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_105),
+		httpkit.WithForceHttp1(),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/http3_test.go
+++ b/tests/http3_test.go
@@ -5,19 +5,19 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Mathious6/httpkit"
+	"github.com/Mathious6/httpkit/profiles"
 	http "github.com/bogdanfinn/fhttp"
-	tls_client "github.com/bogdanfinn/tls-client"
-	"github.com/bogdanfinn/tls-client/profiles"
 )
 
 func TestHTTP3(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_133),
-		tls_client.WithTimeoutSeconds(30),
-		tls_client.WithDebug(),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_133),
+		httpkit.WithTimeoutSeconds(30),
+		httpkit.WithDebug(),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/ja3_test.go
+++ b/tests/ja3_test.go
@@ -3,11 +3,10 @@ package tests
 import (
 	"testing"
 
+	"github.com/Mathious6/httpkit"
 	"github.com/Mathious6/httpkit/profiles"
 	utls "github.com/bogdanfinn/utls"
 	"github.com/stretchr/testify/assert"
-
-	tls_client "github.com/bogdanfinn/tls-client"
 )
 
 func TestJA3(t *testing.T) {
@@ -35,7 +34,7 @@ func ja3_chrome_120(t *testing.T) {
 	alpnProtocols := []string{"h2", "http/1.1"}
 	alpsProtocols := []string{"h2"}
 
-	ccs := []tls_client.CandidateCipherSuites{
+	ccs := []httpkit.CandidateCipherSuites{
 		{
 			KdfId:  "HKDF_SHA256",
 			AeadId: "AEAD_AES_128_GCM",
@@ -48,7 +47,7 @@ func ja3_chrome_120(t *testing.T) {
 	cp := []uint16{128, 160, 192, 224}
 	ca := []string{"zlib"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, ccs, cp, ca, 0)
+	specFunc, err := httpkit.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, ccs, cp, ca, 0)
 
 	if err != nil {
 		t.Fatal(err)
@@ -74,7 +73,7 @@ func ja3_chrome_112_with_psk(t *testing.T) {
 	alpsProtocols := []string{"h2"}
 	ca := []string{"brotli"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca, 0)
+	specFunc, err := httpkit.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca, 0)
 
 	if err != nil {
 		t.Fatal(err)
@@ -100,7 +99,7 @@ func ja3_chrome_105(t *testing.T) {
 	alpsProtocols := []string{"h2"}
 	ca := []string{"zlib"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca, 0)
+	specFunc, err := httpkit.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca, 0)
 
 	if err != nil {
 		t.Fatal(err)
@@ -126,7 +125,7 @@ func ja3_chrome_107(t *testing.T) {
 	alpsProtocols := []string{"h2"}
 	ca := []string{"zlib"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca, 0)
+	specFunc, err := httpkit.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca, 0)
 
 	if err != nil {
 		t.Fatal(err)
@@ -152,7 +151,7 @@ func ja3_firefox_105(t *testing.T) {
 	alpsProtocols := []string{"h2"}
 	ca := []string{"zlib"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca, 0)
+	specFunc, err := httpkit.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca, 0)
 
 	if err != nil {
 		t.Fatal(err)
@@ -178,7 +177,7 @@ func ja3_opera_91(t *testing.T) {
 	alpsProtocols := []string{"h2"}
 	ca := []string{"zlib"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca, 0)
+	specFunc, err := httpkit.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca, 0)
 
 	if err != nil {
 		t.Fatal(err)

--- a/tests/ja3_test.go
+++ b/tests/ja3_test.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	"github.com/bogdanfinn/tls-client/profiles"
+	"github.com/Mathious6/httpkit/profiles"
 	utls "github.com/bogdanfinn/utls"
 	"github.com/stretchr/testify/assert"
 

--- a/tests/keep_alive_test.go
+++ b/tests/keep_alive_test.go
@@ -6,10 +6,10 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/Mathious6/httpkit"
+	"github.com/Mathious6/httpkit/profiles"
 	http "github.com/bogdanfinn/fhttp"
 	"github.com/bogdanfinn/fhttp/httptest"
-	tls_client "github.com/bogdanfinn/tls-client"
-	"github.com/bogdanfinn/tls-client/profiles"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,7 +18,7 @@ func TestClient_UseSameConnection(t *testing.T) {
 	testServer.Start()
 	defer testServer.Close()
 
-	client, err := tls_client.ProvideDefaultClient(tls_client.NewNoopLogger())
+	client, err := httpkit.ProvideDefaultClient(httpkit.NewNoopLogger())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,14 +56,14 @@ func TestClient_UseDifferentConnection(t *testing.T) {
 	testServer.Start()
 	defer testServer.Close()
 
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_107),
-		tls_client.WithTransportOptions(&tls_client.TransportOptions{
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_107),
+		httpkit.WithTransportOptions(&httpkit.TransportOptions{
 			DisableKeepAlives: true,
 		}),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/random_extension_order_test.go
+++ b/tests/random_extension_order_test.go
@@ -3,23 +3,23 @@ package tests
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/bogdanfinn/tls-client/profiles"
 	"io"
 	"strings"
 	"testing"
 
+	"github.com/Mathious6/httpkit"
+	"github.com/Mathious6/httpkit/profiles"
 	http "github.com/bogdanfinn/fhttp"
-	tls_client "github.com/bogdanfinn/tls-client"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_RandomExtensionOrderChrome(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_107),
-		tls_client.WithRandomTLSExtensionOrder(),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_107),
+		httpkit.WithRandomTLSExtensionOrder(),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,12 +64,12 @@ func TestClient_RandomExtensionOrderChrome(t *testing.T) {
 }
 
 func TestClient_RandomExtensionOrderCustom(t *testing.T) {
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.CloudflareCustom),
-		tls_client.WithRandomTLSExtensionOrder(),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.CloudflareCustom),
+		httpkit.WithRandomTLSExtensionOrder(),
 	}
 
-	client, err := tls_client.NewHttpClient(nil, options...)
+	client, err := httpkit.NewHttpClient(nil, options...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/redirect_and_timeout_test.go
+++ b/tests/redirect_and_timeout_test.go
@@ -2,13 +2,13 @@ package tests
 
 import (
 	"fmt"
-	"github.com/bogdanfinn/tls-client/profiles"
 	"testing"
 	"time"
 
+	"github.com/Mathious6/httpkit"
+	"github.com/Mathious6/httpkit/profiles"
 	http "github.com/bogdanfinn/fhttp"
 	"github.com/bogdanfinn/fhttp/httptest"
-	tls_client "github.com/bogdanfinn/tls-client"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,12 +17,12 @@ func TestClient_RedirectNoFollowWithSwitch(t *testing.T) {
 	testServer.Start()
 	defer testServer.Close()
 
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_105),
-		tls_client.WithNotFollowRedirects(),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_105),
+		httpkit.WithNotFollowRedirects(),
 	}
 
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
+	client, err := httpkit.NewHttpClient(httpkit.NewNoopLogger(), options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,11 +56,11 @@ func TestClient_RedirectFollowWithSwitch(t *testing.T) {
 	testServer.Start()
 	defer testServer.Close()
 
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_105),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_105),
 	}
 
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
+	client, err := httpkit.NewHttpClient(httpkit.NewNoopLogger(), options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,12 +94,12 @@ func TestClient_TestFailWithTimeout(t *testing.T) {
 	testServer.Start()
 	defer testServer.Close()
 
-	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_105),
-		tls_client.WithTimeoutSeconds(3),
+	options := []httpkit.HttpClientOption{
+		httpkit.WithClientProfile(profiles.Chrome_105),
+		httpkit.WithTimeoutSeconds(3),
 	}
 
-	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
+	client, err := httpkit.NewHttpClient(httpkit.NewNoopLogger(), options...)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
* Renamed package from `tls_client` to `httpkit` across all source files
* Updated import paths and removed deprecated dependencies
* Introduced `DoWithProxy` method for per-request proxy usage
* Replaced UUID generation with `platekit` for `flowId` support
* Added `WithFlowId` client option and `GetFlowId` method
* Updated `go.mod` with new module path and dependencies
* Refactored examples and tests to use new `httpkit` package structure
